### PR TITLE
BTFS-1762 allow most success for test

### DIFF
--- a/shell_test.go
+++ b/shell_test.go
@@ -464,7 +464,7 @@ func TestStorageUploadWithOnSign(t *testing.T) {
 
 	s := NewShell(shellUrl)
 
-	mhash, err := s.Add(bytes.NewBufferString(string(randBytes(is, 15))), Chunker("reed-solomon-1-1-256000"))
+	mhash, err := s.Add(bytes.NewBufferString(string(randBytes(is, 150))), Chunker("reed-solomon"))
 	is.Nil(err)
 
 	sessionId, err := s.StorageUpload(mhash)
@@ -497,7 +497,7 @@ func TestStorageUploadWithOffSign(t *testing.T) {
 
 	s := NewShell(shellUrl)
 
-	mhash, err := s.Add(bytes.NewBufferString(string(randBytes(is, 15))), Chunker("reed-solomon-1-1-256000"))
+	mhash, err := s.Add(bytes.NewBufferString(string(randBytes(is, 150))), Chunker("reed-solomon"))
 	is.Nil(err)
 
 	uts := s.GetUts()


### PR DESCRIPTION
using the testnet, i needed to make the following changes to get the TestStorageUploadWIthOnSign to pass consistently.